### PR TITLE
feat : 탈퇴시 현재 일자를 테이블에 저장하여 블랙리스트레벨 3 => 탈퇴한 회원 확인하는 기능

### DIFF
--- a/USER_STATUS.sql
+++ b/USER_STATUS.sql
@@ -2,7 +2,7 @@
 -- NULL 아닌사람 조회로 탈퇴 여부 판단 가능
 UPDATE user
 SET user_leave = CURDATE()
-WHERE user_id = '1'
+WHERE user_id = '1';
 
 -- 1번 회원이 DB에서 탈퇴일자 업데이트가 이뤄졌는지 확인
 SELECT user_id, user_leave
@@ -21,24 +21,5 @@ SELECT user_id,
 FROM user
 WHERE user_id = 1; -- user_id가 INT 형이라 따옴표 제거했습니다.
 
--- NEW 를 통해 트리거가 실행 된 이후에 갱신된 값 확인
--- 블랙리스트 레벨이 3이 되었을 경우 회원정보 테이블 user_leave에 현재 일자 저장.
--- 블랙리스트 레벨 3가 되었을경우 user_leave의 값이 NOT NULL 이 되고,
--- 회원아이디를 통해 level3 = 탈퇴한 사람
-DELIMITER //
-
-CREATE TRIGGER blacklist_level_update
-    AFTER UPDATE ON blacklist
-    FOR EACH ROW
-BEGIN
-    -- blacklist 테이블에서 level이 3으로 변경 되면,
-    IF NEW.level = 3 THEN
-    UPDATE 회원정보테이블
-    SET user_leave = CURDATE()
-    WHERE user_id = NEW.user_id; -- blacklist와 회원정보테이블의 user_id 연결
-END IF;
-END //
-
-DELIMITER ;
 
 

--- a/USER_STATUS.sql
+++ b/USER_STATUS.sql
@@ -13,13 +13,13 @@ WHERE user_id = '1';
 -- 탈퇴여부 확인 가능 및, 기능제한 되었다고 판단
 -- <<<#1회원 아이디로 탈퇴한 회원인지 확인하는 구문>>>
 SELECT user_id,
-       name,
+       user_name, -- 컬럼명 수정
        CASE
            WHEN user_leave IS NOT NULL THEN '이 회원은 탈퇴하였습니다.'
            ELSE '정상적으로 기능을 사용할 수 있습니다.'
            END AS 기능상태
 FROM user
-WHERE user_id = '1';
+WHERE user_id = 1; -- user_id가 INT 형이라 따옴표 제거했습니다.
 
 -- NEW 를 통해 트리거가 실행 된 이후에 갱신된 값 확인
 -- 블랙리스트 레벨이 3이 되었을 경우 회원정보 테이블 user_leave에 현재 일자 저장.

--- a/USER_STATUS.sql
+++ b/USER_STATUS.sql
@@ -1,0 +1,44 @@
+-- 회원 탈퇴를 하면 회원 테이블에 탈퇴 일자 생성하는 기능
+-- NULL 아닌사람 조회로 탈퇴 여부 판단 가능
+UPDATE user
+SET user_leave = CURDATE()
+WHERE id = '1'
+
+-- 1번 회원이 DB에서 탈퇴일자 업데이트가 이뤄졌는지 확인
+SELECT user_id, user_leave
+FROM user
+WHERE id = '1';
+
+-- 탈퇴일자가 NOT NULL 일경우 '이 회원은 탈퇴하였습니다'메시지로
+-- 탈퇴여부 확인 가능 및, 기능제한 되었다고 판단
+-- <<<#1회원 아이디로 탈퇴한 회원인지 확인하는 구문>>>
+SELECT id,
+       name,
+       CASE
+           WHEN user_leave IS NOT NULL THEN '이 회원은 탈퇴하였습니다.'
+           ELSE '정상적으로 기능을 사용할 수 있습니다.'
+           END AS 기능상태
+FROM user
+WHERE id = '1';
+
+-- NEW 를 통해 트리거가 실행 된 이후에 갱신된 값 확인
+-- 블랙리스트 레벨이 3이 되었을 경우 회원정보 테이블 user_leave에 현재 일자 저장.
+-- 블랙리스트 레벨 3가 되었을경우 user_leave의 값이 NOT NULL 이 되고,
+-- 회원아이디를 통해 level3 = 탈퇴한 사람
+DELIMITER //
+
+CREATE TRIGGER blacklist_level_update
+    AFTER UPDATE ON blacklist
+    FOR EACH ROW
+BEGIN
+    -- blacklist 테이블에서 level이 3으로 변경 되면,
+    IF NEW.level = 3 THEN
+    UPDATE 회원정보테이블
+    SET user_leave = CURDATE()
+    WHERE user_id = NEW.user_id; -- blacklist와 회원정보테이블의 user_id 연결
+END IF;
+END //
+
+DELIMITER ;
+
+

--- a/USER_STATUS.sql
+++ b/USER_STATUS.sql
@@ -2,24 +2,24 @@
 -- NULL 아닌사람 조회로 탈퇴 여부 판단 가능
 UPDATE user
 SET user_leave = CURDATE()
-WHERE id = '1'
+WHERE user_id = '1'
 
 -- 1번 회원이 DB에서 탈퇴일자 업데이트가 이뤄졌는지 확인
 SELECT user_id, user_leave
 FROM user
-WHERE id = '1';
+WHERE user_id = '1';
 
 -- 탈퇴일자가 NOT NULL 일경우 '이 회원은 탈퇴하였습니다'메시지로
 -- 탈퇴여부 확인 가능 및, 기능제한 되었다고 판단
 -- <<<#1회원 아이디로 탈퇴한 회원인지 확인하는 구문>>>
-SELECT id,
+SELECT user_id,
        name,
        CASE
            WHEN user_leave IS NOT NULL THEN '이 회원은 탈퇴하였습니다.'
            ELSE '정상적으로 기능을 사용할 수 있습니다.'
            END AS 기능상태
 FROM user
-WHERE id = '1';
+WHERE user_id = '1';
 
 -- NEW 를 통해 트리거가 실행 된 이후에 갱신된 값 확인
 -- 블랙리스트 레벨이 3이 되었을 경우 회원정보 테이블 user_leave에 현재 일자 저장.

--- a/blacklist_level_update_trigger.sql
+++ b/blacklist_level_update_trigger.sql
@@ -1,0 +1,19 @@
+-- NEW 를 통해 트리거가 실행 된 이후에 갱신된 값 확인
+-- 블랙리스트 레벨이 3이 되었을 경우 회원정보 테이블 user_leave에 현재 일자 저장.
+-- 블랙리스트 레벨 3가 되었을경우 user_leave의 값이 NOT NULL 이 되고,
+-- 회원아이디를 통해 level3 = 탈퇴한 사람
+DELIMITER //
+
+CREATE TRIGGER blacklist_level_update
+    AFTER UPDATE ON blacklist
+    FOR EACH ROW
+BEGIN
+    -- blacklist 테이블에서 level이 3으로 변경 되면,
+    IF NEW.level = 3 THEN
+    UPDATE user
+    SET user_leave = CURDATE()
+    WHERE user_id = NEW.user_id; -- blacklist와 회원정보테이블의 user_id 연결
+END IF;
+END //
+
+DELIMITER ;


### PR DESCRIPTION
---
name: 회원 상태 기능
about: 회원 탈퇴시 user_leave에 현재 일자 저장, 블랙리스트 레벨 3이 되었을 경우도 user_leave에 현재 일자 저장하여
user_leave가 NOT NULL 이면 탈퇴한 회원이라는 판단을 할 수 있는 코드
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 회원 탈퇴를 하는 기능은 서버에서 기능 하는것이라고 생각하고 
- 우선 테스트 케이스에서는 user_leave에 값을 임의로 넣어 '탈퇴한 회원 '
이라는 가정을 하고 확인할 것인지?

## 관련 스크린 샷 

## 테스트 계획 또는 완료 사항
- [ ] 테스트항목 1
- [ ] 테스트항목 2

- [ ] 
