### PR TITLE
대댓글 not null -> null로 수정

### DIFF
--- a/HEALTH.sql
+++ b/HEALTH.sql
@@ -267,7 +267,7 @@ CREATE TABLE IF NOT EXISTS comment
     comment_is_blinded BOOLEAN      NOT NULL DEFAULT FALSE,
     user_id            INT          NOT NULL,
     post_id            INT          NOT NULL,
-    comment_id2        INT          NOT NULL,
+    comment_id2        INT          NULL,
     PRIMARY KEY (comment_id),
     FOREIGN KEY (user_id) REFERENCES user (user_id),
     FOREIGN KEY (post_id) REFERENCES community_post (post_id),


### PR DESCRIPTION
---
name: 댓글 대댓글 not null 문제 해결
about: 댓글이 항상 어떤 댓글의 대댓글이어야 했던 문제 해결
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 댓글이 항상 어떤 댓글의 대댓글이어야 했던 문제 해결


## 어떤 부분에 리뷰어가 집중하면 좋은가
- comment table id 2not null -> null

#37 
