### PR TITLE
fix/3 - 유저 회원정보 수정 기능 

### DIFF
--- a/user/user_update.sql
+++ b/user/user_update.sql
@@ -12,5 +12,5 @@ SET
     user_weight = 75.0,
     user_leave = NULL,  -- 탈퇴일이 없을 경우 NULL로 설정
     user_report = 0,    -- 신고 횟수를 초기화하거나 특정 값으로 설정
-    user_grant = 'A'    -- 권한 등급을 'A'로 설정
+    user_grant = 'N'
 WHERE user_id = 1;      -- 수정할 사용자의 ID


### PR DESCRIPTION
user_gramt 컬럼 데이터 값 A로 되있고
주석또한 권한 등급을 A로 설정이라고 되어있는데
user_grant는 Y,N 관리자 확인 유무 column임

A -> N으로 변경

---
name: 유저 회원정보 수정 기능
about: user_grant 데이터 설정 잘못되어서 주석 제거및 값 테스트케이스 값 변경
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- user_grant 값 설정 잘못됨. 주석 제거 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷 

## 테스트 계획 또는 완료 사항
- [ ] 테스트항목 1
- [ ] 테스트항목 2

- [ ] 

@Morris235 